### PR TITLE
Opening data access

### DIFF
--- a/Pubnative/Scripts/PNNative.cs
+++ b/Pubnative/Scripts/PNNative.cs
@@ -17,7 +17,8 @@ namespace Pubnative
         public Texture2D banner;
         public Texture2D portrait_banner;
 
-        private PNNativeModel data = null;
+        public PNNativeModel data = null;
+        
         private int readyCounter = 0;
 
         protected override string APIName ()


### PR DESCRIPTION
This patch actually opens access to the downloaded data in the model (as PNImage is also). 

It's needed to access to the data like title, description and so on. So this fix it :)
